### PR TITLE
Update osx_pl2303.cpp

### DIFF
--- a/osx_pl2303.cpp
+++ b/osx_pl2303.cpp
@@ -3374,11 +3374,33 @@ IOReturn nl_bjaelectronics_driver_PL2303::setSerialConfiguration( void )
 		case 460800:
 			fBaudCode = kLinkSpeed460800;  // 0x08
 			break;	    
+		case 614400:
+			fBaudCode = kLinkSpeed614400;  // 0x08
+			break;
+		case 921600:
+			fBaudCode = kLinkSpeed921600;  // 0x08
+			break;
+		case 1228800:
+			fBaudCode = kLinkSpeed1228800;  // 0x08
+			break;
+		case 1843200:
+			fBaudCode = kLinkSpeed1843200;  // 0x08
+			break;
+		case 2457600:
+			fBaudCode = kLinkSpeed2457600;  // 0x08
+			break;
+		case 3000000:
+			fBaudCode = kLinkSpeed3000000;  // 0x08
+			break;
+		case 6000000:
+			fBaudCode = kLinkSpeed6000000;  // 0x08
+			break;
 			
-			
+            // Other baudrates may be depend on the model (see manual on page 19)
+            // I changed the error into a warning...
 		default:
-			IOLog("%s(%p)::setSerialConfiguration - Unsupported baud rate\n", getName(), this);
-			fBaudCode = 0;
+			IOLog("%s(%p)::setSerialConfiguration - Requesting non standard baud rate\n", getName(), this);
+			fBaudCode = fPort->BaudRate;
 			break;
     }
 	


### PR DESCRIPTION
Modified to support higher speed rates as supported by PL2303HX, Tested on my OSX 10.8.4 at 921600 bps
